### PR TITLE
Multi-line Expressions and Other Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ With the `-env` flag you can use DFL filters against the current environment.
 You can use DFL to filter integer arrays.
 
 ```
-./dfl -verbose -f '@a == [1, 2, 3, 4]' 'a=[1, 2, 3, 4]'
+./dfl -f '@a == [1, 2, 3, 4]' 'a=[1, 2, 3, 4]'
 # returns true as exit code 0
 ```
 
@@ -86,7 +86,7 @@ You can also use DFl to compare byte arrays.
 You can use DFL to filter IP addresses.
 
 ```
-./dfl -verbose -f '@ip in 10.10.0.0/16' ip=10.10.20.22
+./dfl -f '@ip in 10.10.0.0/16' ip=10.10.20.22
 # returns true as exit code 0
 ```
 

--- a/cmd/dfl.js/main.go
+++ b/cmd/dfl.js/main.go
@@ -30,10 +30,14 @@ var GO_DFL_VERSION = "0.0.3"
 
 type Node struct {
 	Node dfl.Node
+	FunctionMap dfl.FunctionMap
 }
 
 func (n Node) Compile() *js.Object {
-	return js.MakeWrapper(Node{Node:n.Node.Compile()})
+	return js.MakeWrapper(Node{
+		Node: n.Node.Compile(),
+		FunctionMap: dfl.NewFuntionMapWithDefaults(),
+	})
 }
 
 func (n Node) Evaluate(options *js.Object) interface{} {
@@ -43,7 +47,7 @@ func (n Node) Evaluate(options *js.Object) interface{} {
 		ctx[key] = options.Get(key).Interface()
 	}
 
-	result, err := n.Node.Evaluate(ctx, dfl.FunctionMap{})
+	result, err := n.Node.Evaluate(ctx, n.FunctionMap)
 	if err != nil {
 		console.Log(err.Error())
 		return false
@@ -87,7 +91,7 @@ func EvaluateBool(s string, options *js.Object) bool {
 		ctx[key] = options.Get(key).Interface()
 	}
 
-	result, err := dfl.EvaluateBool(root, ctx, dfl.FunctionMap{})
+	result, err := dfl.EvaluateBool(root, ctx, dfl.NewFuntionMapWithDefaults())
 	if err != nil {
 		console.Log(err.Error())
 		return false
@@ -110,7 +114,7 @@ func EvaluateInt(s string, options *js.Object) int {
 		ctx[key] = options.Get(key).Interface()
 	}
 
-	result, err := dfl.EvaluateInt(root, ctx, dfl.FunctionMap{})
+	result, err := dfl.EvaluateInt(root, ctx, dfl.NewFuntionMapWithDefaults())
 	if err != nil {
 		console.Log(err.Error())
 		return 0
@@ -133,7 +137,7 @@ func EvaluateFloat64(s string, options *js.Object) float64 {
 		ctx[key] = options.Get(key).Interface()
 	}
 
-	result, err := dfl.EvaluateFloat64(root, ctx, dfl.FunctionMap{})
+	result, err := dfl.EvaluateFloat64(root, ctx, dfl.NewFuntionMapWithDefaults())
 	if err != nil {
 		console.Log(err.Error())
 		return 0.0
@@ -156,7 +160,7 @@ func EvaluateString(s string, options *js.Object) string {
 		ctx[key] = options.Get(key).Interface()
 	}
 
-	result, err := dfl.EvaluateString(root, ctx, dfl.FunctionMap{})
+	result, err := dfl.EvaluateString(root, ctx, dfl.NewFuntionMapWithDefaults())
 	if err != nil {
 		console.Log(err.Error())
 		return ""

--- a/cmd/dfl/main.go
+++ b/cmd/dfl/main.go
@@ -46,19 +46,6 @@ import (
 
 var GO_DFL_VERSION = "0.0.3"
 
-func dfl_build_funcs() dfl.FunctionMap {
-	funcs := dfl.FunctionMap{}
-
-	funcs["len"] = func(ctx dfl.Context, args []string) (interface{}, error) {
-		if len(args) != 1 {
-			return 0, errors.New("Invalid number of arguments to len.")
-		}
-		return len(args[0]), nil
-	}
-
-	return funcs
-}
-
 func main() {
 
 	start := time.Now()
@@ -171,8 +158,7 @@ func main() {
 		fmt.Println(string(out))
 	}
 
-	funcs := dfl_build_funcs()
-	result, err := root.Evaluate(ctx, funcs)
+	result, err := root.Evaluate(ctx, dfl.NewFuntionMapWithDefaults())
 	if err != nil {
 		fmt.Println("Error evaluating expression.")
 		fmt.Println(err)

--- a/dfl/AttachLeft.go
+++ b/dfl/AttachLeft.go
@@ -1,0 +1,55 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"github.com/pkg/errors"
+)
+
+// AttachLeft attaches the left Node as the left child node to the parent root Node.
+func AttachLeft(root Node, left Node) error {
+	switch root.(type) {
+	case *And:
+		root.(*And).Left = left
+	case *Or:
+		root.(*Or).Left = left
+	case *Xor:
+		root.(*Xor).Left = left
+	case *Coalesce:
+		root.(*Coalesce).Left = left
+	case *In:
+		root.(*In).Left = left
+	case *Like:
+		root.(*Like).Left = left
+	case *ILike:
+		root.(*ILike).Left = left
+	case *LessThan:
+		root.(*LessThan).Left = left
+	case *LessThanOrEqual:
+		root.(*LessThanOrEqual).Left = left
+	case *GreaterThan:
+		root.(*GreaterThan).Left = left
+	case *GreaterThanOrEqual:
+		root.(*GreaterThanOrEqual).Left = left
+	case *Equal:
+		root.(*Equal).Left = left
+	case *NotEqual:
+		root.(*NotEqual).Left = left
+	case *Add:
+		root.(*Add).Left = left
+	case *Subtract:
+		root.(*Subtract).Left = left
+	case *Before:
+		root.(*Before).Left = left
+	case *After:
+		root.(*After).Left = left
+	default:
+		return errors.New("Could not attach left as root is not a binary operator")
+	}
+	return nil
+}

--- a/dfl/Attribute.go
+++ b/dfl/Attribute.go
@@ -7,7 +7,9 @@
 
 package dfl
 
-// Array is a Node representing the value of an attribute in the context map.
+// Attribute is a Node representing the value of an attribute in the context map.
+// Attributes start with a "@" and follow with the name or full path into the object if multiple levels deep.
+// For example, @a and @a.b.c.d.  You can also use a null-safe operator, e.g., @a?.b?.c?.d
 type Attribute struct {
 	Name string
 }
@@ -23,15 +25,11 @@ func (a Attribute) Map() map[string]interface{} {
 }
 
 func (a Attribute) Compile() Node {
-	return a
+	return Attribute{Name: a.Name}
 }
 
 func (a Attribute) Evaluate(ctx Context, funcs FunctionMap) (interface{}, error) {
-	if v, ok := ctx[a.Name]; ok {
-		return v, nil
-	} else {
-		return "", nil
-	}
+	return Extract(a.Name, ctx)
 }
 
 func (a Attribute) Attributes() []string {

--- a/dfl/Attribute_test.go
+++ b/dfl/Attribute_test.go
@@ -1,0 +1,63 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"reflect"
+	"testing"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+func TestAttribute(t *testing.T) {
+
+	ctx := Context{
+		"a": nil,
+		"b": nil,
+		"c": map[string]interface{}{"d": 10, "e": map[string]interface{}{"f": 100}},
+		"g": []int{10, 20, 30},
+		"h": map[string]interface{}{"i": []int{10, 20, 30, 40}},
+		"j": "bars",
+		"k": []map[string]interface{}{
+			map[string]interface{}{"l": "m"},
+		},
+	}
+
+	testCases := []TestCase{
+		NewTestCase("(@a?.d ?: 10) == 10", ctx, true),
+		NewTestCase("@c?.d == 10", ctx, true),
+		NewTestCase("@c.d == 10", ctx, true),
+		NewTestCase("@c.e.f == 100", ctx, true),
+		NewTestCase("@c.e?.f == 100", ctx, true),
+		NewTestCase("@g[0] == 10", ctx, true),
+		NewTestCase("@g[0:2] == [10,20]", ctx, true),
+		NewTestCase("@h?.i[1:3] == [20,30]", ctx, true),
+		NewTestCase("@h?.i[1:3] == [20,30]", ctx, true),
+		NewTestCase("@j[0:3] == bar", ctx, true),
+		NewTestCase("@j[:3] == bar", ctx, true),
+		NewTestCase("@k[0]l == m", ctx, true),
+	}
+
+	for _, testCase := range testCases {
+		node, err := Parse(testCase.Expression)
+		if err != nil {
+			t.Errorf(errors.Wrap(err, "Error parsing expression \""+testCase.Expression+"\"").Error())
+			continue
+		}
+		node = node.Compile()
+		got, err := node.Evaluate(testCase.Context, FunctionMap{})
+		if err != nil {
+			t.Errorf(errors.Wrap(err, "Error evaluating expression \""+testCase.Expression+"\"").Error())
+		} else if got != testCase.Result {
+			t.Errorf("TestAttribute(%q) == %v (%q), want %v (%q)", testCase.Expression, got, reflect.TypeOf(got), testCase.Result, reflect.TypeOf(testCase.Result))
+		}
+	}
+
+}

--- a/dfl/Coalesce.go
+++ b/dfl/Coalesce.go
@@ -1,0 +1,60 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Coalesce is a BinaryOperator which returns the left value if not null otherwise the right value.
+type Coalesce struct {
+	*BinaryOperator
+}
+
+func (c Coalesce) Dfl() string {
+	return "(" + c.Left.Dfl() + " ?: " + c.Right.Dfl() + ")"
+}
+
+func (c Coalesce) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "?:",
+		"left":  c.Left.Map(),
+		"right": c.Right.Map(),
+	}
+}
+
+// Compile returns a compiled version of this node.
+// If the left value is compiled as a Literal, then returns the left value.
+// Otherwise, returns a clone.
+func (c Coalesce) Compile() Node {
+	left := c.Left.Compile()
+	switch left.(type) {
+	case Literal:
+		return Literal{Value: left.(Literal).Value}
+	}
+	right := c.Right.Compile()
+	return Coalesce{&BinaryOperator{Left: left, Right: right}}
+}
+
+func (c Coalesce) Evaluate(ctx Context, funcs FunctionMap) (interface{}, error) {
+	lv, err := c.Left.Evaluate(ctx, funcs)
+	if err != nil {
+		return lv, errors.Wrap(err, "Error evaluating Coalesce left value")
+	}
+
+	switch lv.(type) {
+	case Null:
+		rv, err := c.Right.Evaluate(ctx, funcs)
+		if err != nil {
+			return rv, errors.Wrap(err, "Error evaluating Coalesce right value")
+		}
+		return rv, nil
+	}
+
+	return lv, nil
+}

--- a/dfl/Coalesce_test.go
+++ b/dfl/Coalesce_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestAnd(t *testing.T) {
+func TestCoalesce(t *testing.T) {
 
-	ctx := Context{"a": true, "b": false}
+	ctx := Context{"a": nil, "b": 10, "c": 10}
 
 	testCases := []TestCase{
-		NewTestCase("true and false", ctx, false),
-		NewTestCase("@a and true", ctx, true),
-		NewTestCase("false and @b", ctx, false),
-		NewTestCase("@a and @b", ctx, false),
+		NewTestCase("(@a ?: 10) == 10", ctx, true),
+		NewTestCase("(@a ?: @b) == 10", ctx, true),
+		NewTestCase("(@a ?: @Z ?: @c) == 10", ctx, true),
+		NewTestCase("(@a ?: @Z ?: @c) == 15", ctx, false),
 	}
 
 	for _, testCase := range testCases {
@@ -38,7 +38,7 @@ func TestAnd(t *testing.T) {
 		if err != nil {
 			t.Errorf(errors.Wrap(err, "Error evaluating expression \""+testCase.Expression+"\"").Error())
 		} else if got != testCase.Result {
-			t.Errorf("TestAnd(%q) == %v (%q), want %v (%q)", testCase.Expression, got, reflect.TypeOf(got), testCase.Result, reflect.TypeOf(testCase.Result))
+			t.Errorf("TestCoalesce(%q) == %v (%q), want %v (%q)", testCase.Expression, got, reflect.TypeOf(got), testCase.Result, reflect.TypeOf(testCase.Result))
 		}
 	}
 

--- a/dfl/Counter.go
+++ b/dfl/Counter.go
@@ -1,5 +1,13 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
 package dfl
 
+// Counter is used for creating a frequency histogram of values
 type Counter map[string]int
 
 func (c Counter) Len() int {

--- a/dfl/Equal.go
+++ b/dfl/Equal.go
@@ -44,6 +44,14 @@ func (e Equal) Evaluate(ctx Context, funcs FunctionMap) (interface{}, error) {
 	}
 
 	switch lv.(type) {
+	case byte:
+		lvs := lv.(byte)
+		switch rv.(type) {
+		case string:
+			return string([]byte{lvs}) == rv.(string), nil
+		case uint8:
+			return lvs == (rv.(byte)), nil
+		}
 	case string:
 		lvs := lv.(string)
 		switch rv.(type) {

--- a/dfl/Extract.go
+++ b/dfl/Extract.go
@@ -1,0 +1,252 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Extract is a function to extract a value from an object.
+// Extract supports a standard dot (.) and null-safe (?.) indexing.
+// Extract also support array indexing, including [A], [A:B], [A:], and [:B].
+func Extract(path string, obj interface{}) (interface{}, error) {
+
+	index_questionmark := -1
+	index_period := -1
+	slice_start_index := -1
+	slice_end_index := -1
+
+	for i, c := range path {
+		if c == '?' {
+			index_questionmark = i
+			if i+1 < len(path) && path[i+1] == '.' {
+				index_period = i + 1
+				break
+			} else {
+				return Null{}, errors.New("Invalid path " + path)
+			}
+		} else if c == '.' {
+			index_period = i
+			break
+		} else if c == '[' {
+			slice_start_index = i
+			for j, c := range path[i+1 : len(path)] {
+				if c == ']' {
+					slice_end_index = j
+					break
+				}
+			}
+			break
+		}
+	}
+
+	if index_period != -1 {
+		if index_questionmark != -1 {
+			key := path[0:index_questionmark]
+			remainder := path[index_period+1 : len(path)]
+
+			switch obj.(type) {
+			case Context:
+				if value, ok := obj.(Context)[key]; ok {
+					if value == nil {
+						return Null{}, nil
+					}
+					return Extract(remainder, value)
+				}
+				return Null{}, nil
+			case map[string]interface{}:
+				if value, ok := obj.(map[string]interface{})[key]; ok {
+					if value == nil {
+						return Null{}, nil
+					}
+					return Extract(remainder, value)
+				}
+				return Null{}, nil
+			}
+			return Null{}, errors.New("object is invalid type " + reflect.TypeOf(obj).String())
+
+		} else {
+			key := path[0:index_period]
+			remainder := path[index_period+1 : len(path)]
+
+			switch obj.(type) {
+			case Context:
+				if value, ok := obj.(Context)[key]; ok {
+					if value == nil {
+						return Null{}, errors.New("value " + key + " is null.")
+					}
+					return Extract(remainder, value)
+				}
+				return Null{}, errors.New("value " + key + " is null.")
+			case map[string]interface{}:
+				if value, ok := obj.(map[string]interface{})[key]; ok {
+					if value == nil {
+						return Null{}, errors.New("value " + key + " is null.")
+					}
+					return Extract(remainder, value)
+				}
+				return Null{}, errors.New("value " + key + " is null.")
+			}
+			return Null{}, errors.New("object is invalid type " + reflect.TypeOf(obj).String())
+
+		}
+	} else if slice_start_index != -1 && slice_end_index != -1 {
+		if slice_start_index == 0 {
+			remainder := path[slice_end_index+2:]
+			pair := strings.Split(path[1:slice_end_index+1], ":")
+			if len(pair) == 2 {
+				start := 0
+				if len(pair[0]) > 0 {
+					i, err := strconv.Atoi(pair[0])
+					if err != nil {
+						return Null{}, errors.New("slice start \"" + pair[0] + "\" is invalid ")
+					}
+					start = i
+				}
+
+				if len(pair[1]) > 0 {
+					end, err := strconv.Atoi(pair[1])
+					if err != nil {
+						return Null{}, errors.New("slice end \"" + pair[1] + "\" is invalid ")
+					}
+
+					switch o := obj.(type) {
+					case string:
+						return o[start:end], nil
+					case []byte:
+						return o[start:end], nil
+					case []int:
+						return o[start:end], nil
+					case []string:
+						return o[start:end], nil
+					case []map[string]interface{}:
+						if len(remainder) > 0 {
+							return Extract(remainder, o[start:end])
+						}
+						return o[start:end], nil
+					case []map[string]string:
+						if len(remainder) > 0 {
+							return Extract(remainder, o[start:end])
+						}
+						return o[start:end], nil
+					}
+
+				} else {
+
+					switch o := obj.(type) {
+					case string:
+						return o[start:], nil
+					case []byte:
+						return o[start:], nil
+					case []int:
+						return o[start:], nil
+					case []string:
+						return o[start:], nil
+					case []map[string]interface{}:
+						if len(remainder) > 0 {
+							return Extract(remainder, o[start:])
+						}
+						return o[start:], nil
+					case []map[string]string:
+						if len(remainder) > 0 {
+							return Extract(remainder, o[start:])
+						}
+						return o[start:], nil
+					}
+
+				}
+
+				return Null{}, errors.New("object \"" + fmt.Sprint(obj) + "\" (" + reflect.TypeOf(obj).String() + ") is not a slice.")
+
+			} else if len(pair) == 1 {
+				slice_index, err := strconv.Atoi(pair[0])
+				if err != nil {
+					return Null{}, errors.New("slice index \"" + pair[0] + "\" is invalid ")
+				}
+				switch o := obj.(type) {
+				case string:
+					return o[slice_index], nil
+				case []byte:
+					return o[slice_index], nil
+				case []int:
+					return o[slice_index], nil
+				case []string:
+					return o[slice_index], nil
+				case []map[string]interface{}:
+					if len(remainder) > 0 {
+						return Extract(remainder, o[slice_index])
+					}
+					return o[slice_index], nil
+				case []map[string]string:
+					if len(remainder) > 0 {
+						return Extract(remainder, o[slice_index])
+					}
+					return o[slice_index], nil
+				}
+				return Null{}, errors.New("object \"" + fmt.Sprint(obj) + "\" (" + reflect.TypeOf(obj).String() + ") is not a slice.")
+			}
+			return Null{}, errors.New("slice range \"" + (path[1:slice_end_index]) + "\" is invalid ")
+		} else {
+			key := path[0:slice_start_index]
+			remainder := path[slice_start_index:len(path)]
+			switch o := obj.(type) {
+			case Context:
+				if value, ok := o[key]; ok {
+					if value == nil {
+						return Null{}, errors.New("value " + key + " is null.")
+					}
+					return Extract(remainder, value)
+				}
+				return Null{}, errors.New("value " + key + " is null.")
+			case map[string]interface{}:
+				if value, ok := o[key]; ok {
+					if value == nil {
+						return Null{}, errors.New("value " + key + " is null.")
+					}
+					return Extract(remainder, value)
+				}
+				return Null{}, errors.New("value " + key + " is null.")
+			}
+			return Null{}, errors.New("object is invalid type " + reflect.TypeOf(obj).String())
+		}
+	}
+
+	switch obj.(type) {
+	case Context:
+		if value, ok := obj.(Context)[path]; ok {
+			if value == nil {
+				return Null{}, nil
+			}
+			return value, nil
+		}
+		return Null{}, nil
+	case map[string]interface{}:
+		if value, ok := obj.(map[string]interface{})[path]; ok {
+			if value == nil {
+				return Null{}, nil
+			}
+			return value, nil
+		}
+		return Null{}, nil
+	case map[string]string:
+		if value, ok := obj.(map[string]string)[path]; ok {
+			return value, nil
+		}
+		return Null{}, nil
+	}
+
+	return Null{}, errors.New("object is invalid type " + reflect.TypeOf(obj).String())
+
+}

--- a/dfl/FunctionMap.go
+++ b/dfl/FunctionMap.go
@@ -7,5 +7,270 @@
 
 package dfl
 
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
 // FunctionMap is a map of functions by string that are reference by name in the Function Node.
-type FunctionMap map[string]func(Context, []string) (interface{}, error)
+type FunctionMap map[string]func(Context, []interface{}) (interface{}, error)
+
+func NewFuntionMapWithDefaults() FunctionMap {
+	funcs := FunctionMap{}
+
+	funcs["map"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return 0, errors.New("Invalid number of arguments to map.")
+		}
+
+		switch key := args[1].(type) {
+		case string:
+			switch a := args[0].(type) {
+			case []map[string]interface{}:
+				values := make([]interface{}, 0, len(a))
+				for _, value := range a {
+					values = append(values, value[key])
+				}
+				return values, nil
+			case []map[string]string:
+				values := make([]string, 0, len(a))
+				for _, value := range a {
+					values = append(values, value[key])
+				}
+				return values, nil
+			}
+
+			return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+		}
+
+		return 0, errors.New("Invalid key for map function")
+
+	}
+
+	funcs["split"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return 0, errors.New("Invalid number of arguments to split.")
+		}
+		return strings.Split(fmt.Sprint(args[0]), fmt.Sprint(args[1])), nil
+	}
+
+	funcs["trim"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to split.")
+		}
+
+		switch a := args[0].(type) {
+		case string:
+			return strings.TrimSpace(a), nil
+		case []byte:
+			return []byte(strings.TrimSpace(string(a))), nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["len"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to len.")
+		}
+
+		switch a := args[0].(type) {
+		case string:
+			return len(a), nil
+		case []int:
+			return len(a), nil
+		case []string:
+			return len(a), nil
+		case []uint8:
+			return len(a), nil
+		case []float64:
+			return len(a), nil
+		case []interface{}:
+			return len(a), nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["bytes"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to len.")
+		}
+		switch a := args[0].(type) {
+		case string:
+			return []byte(a), nil
+		case byte:
+			return []byte{a}, nil
+		case []byte:
+			return a, nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["int32"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to int32.")
+		}
+		switch a := args[0].(type) {
+		case int:
+			return int32(a), nil
+		case int32:
+			return a, nil
+		case int64:
+			return int32(a), nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["big"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to big.")
+		}
+		switch a := args[0].(type) {
+		case int:
+			buf := new(bytes.Buffer)
+			err := binary.Write(buf, binary.BigEndian, int64(a))
+			return buf.Bytes(), err
+		case int32:
+			buf := new(bytes.Buffer)
+			err := binary.Write(buf, binary.BigEndian, a)
+			return buf.Bytes(), err
+		case int64:
+			buf := new(bytes.Buffer)
+			err := binary.Write(buf, binary.BigEndian, a)
+			return buf.Bytes(), err
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["repeat"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 2 {
+			return 0, errors.New("Invalid number of arguments to repeat.")
+		}
+		switch value := args[0].(type) {
+		case string:
+			switch count := args[1].(type) {
+			case int:
+				return strings.Repeat(value, count), nil
+			}
+		case []byte:
+			switch count := args[1].(type) {
+			case int:
+				return bytes.Repeat(value, count), nil
+			}
+		case byte:
+			switch count := args[1].(type) {
+			case int:
+				return bytes.Repeat([]byte{value}, count), nil
+			}
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["string"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to len.")
+		}
+		switch a := args[0].(type) {
+		case string:
+			return a, nil
+		case []byte:
+			return string(a), nil
+		case byte:
+			return string([]byte{a}), nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["min"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) < 1 {
+			return 0, errors.New("Invalid number of arguments to len.")
+		}
+
+		return Min(TryConvertArray(args))
+	}
+
+	funcs["max"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) < 1 {
+			return 0, errors.New("Invalid number of arguments to len.")
+		}
+
+		return Max(TryConvertArray(args))
+	}
+
+	funcs["lower"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to upper.")
+		}
+		switch a := args[0].(type) {
+		case string:
+			return strings.ToLower(a), nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["upper"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to upper.")
+		}
+		switch a := args[0].(type) {
+		case string:
+			return strings.ToUpper(a), nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["first"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to upper.")
+		}
+
+		switch a := args[0].(type) {
+		case string:
+			return a[0], nil
+		case []byte:
+			return a[0], nil
+		case []int:
+			return a[0], nil
+		case []float64:
+			return a[0], nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	funcs["last"] = func(ctx Context, args []interface{}) (interface{}, error) {
+		if len(args) != 1 {
+			return 0, errors.New("Invalid number of arguments to upper.")
+		}
+
+		switch a := args[0].(type) {
+		case string:
+			return a[len(a)-1], nil
+		case []byte:
+			return a[len(a)-1], nil
+		case []int:
+			return a[len(a)-1], nil
+		case []float64:
+			return a[len(a)-1], nil
+		}
+
+		return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(args[0]).String())
+	}
+
+	return funcs
+}

--- a/dfl/Function_test.go
+++ b/dfl/Function_test.go
@@ -16,15 +16,26 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestAnd(t *testing.T) {
+func TestFunction(t *testing.T) {
 
-	ctx := Context{"a": true, "b": false}
+	ctx := Context{
+		"a": 2,
+		"b": 3.0,
+		"c": "PNG",
+		"d": []map[string]interface{}{
+			map[string]interface{}{"e": "f"},
+			map[string]interface{}{"e": "h"},
+		},
+	}
 
 	testCases := []TestCase{
-		NewTestCase("true and false", ctx, false),
-		NewTestCase("@a and true", ctx, true),
-		NewTestCase("false and @b", ctx, false),
-		NewTestCase("@a and @b", ctx, false),
+		NewTestCase("min(1, @a) == 1", ctx, true),
+		NewTestCase("min(2, @b) == 2", ctx, true),
+		NewTestCase("max(3, @a) == 3", ctx, true),
+		NewTestCase("min(3, @b) == 3.0", ctx, true),
+		NewTestCase("min(1, max(@a, @b)) == 1", ctx, true),
+		NewTestCase("len(bytes(@c)) == 3", ctx, true),
+		NewTestCase("f in map(@d, e)", ctx, true),
 	}
 
 	for _, testCase := range testCases {
@@ -34,11 +45,11 @@ func TestAnd(t *testing.T) {
 			continue
 		}
 		node = node.Compile()
-		got, err := node.Evaluate(testCase.Context, FunctionMap{})
+		got, err := node.Evaluate(testCase.Context, NewFuntionMapWithDefaults())
 		if err != nil {
 			t.Errorf(errors.Wrap(err, "Error evaluating expression \""+testCase.Expression+"\"").Error())
 		} else if got != testCase.Result {
-			t.Errorf("TestAnd(%q) == %v (%q), want %v (%q)", testCase.Expression, got, reflect.TypeOf(got), testCase.Result, reflect.TypeOf(testCase.Result))
+			t.Errorf("TestFunction(%q) == %v (%q), want %v (%q)", testCase.Expression, got, reflect.TypeOf(got), testCase.Result, reflect.TypeOf(testCase.Result))
 		}
 	}
 

--- a/dfl/GreaterThanOrEqual.go
+++ b/dfl/GreaterThanOrEqual.go
@@ -14,7 +14,7 @@ type GreaterThanOrEqual struct {
 }
 
 func (gte GreaterThanOrEqual) Dfl() string {
-	return "(" + gte.Left.Dfl() + " > " + gte.Right.Dfl() + ")"
+	return "(" + gte.Left.Dfl() + " >= " + gte.Right.Dfl() + ")"
 }
 
 func (gte GreaterThanOrEqual) Map() map[string]interface{} {

--- a/dfl/Max.go
+++ b/dfl/Max.go
@@ -1,0 +1,46 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"reflect"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Max returns the maximum value of the elements of the given slice.  If values is not a slice, then returns an error.
+func Max(values interface{}) (interface{}, error) {
+	switch v := values.(type) {
+	case []int:
+		if len(v) == 0 {
+			return Null{}, errors.New("Invalid length of " + reflect.TypeOf(v).String())
+		}
+		max := v[0]
+		for i := 1; i < len(v); i++ {
+			if v[i] > max {
+				max = v[i]
+			}
+		}
+		return max, nil
+	case []float64:
+		if len(v) == 0 {
+			return Null{}, errors.New("Invalid length of " + reflect.TypeOf(v).String())
+		}
+		max := v[0]
+		for i := 1; i < len(v); i++ {
+			if v[i] > max {
+				max = v[i]
+			}
+		}
+		return max, nil
+	}
+
+	return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(values).String())
+}

--- a/dfl/Min.go
+++ b/dfl/Min.go
@@ -1,0 +1,46 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"reflect"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Min returns the minimum value of the elements of the given slice.  If values is not a slice, then returns an error.
+func Min(values interface{}) (interface{}, error) {
+	switch v := values.(type) {
+	case []int:
+		if len(v) == 0 {
+			return Null{}, errors.New("Invalid length of " + reflect.TypeOf(v).String())
+		}
+		min := v[0]
+		for i := 1; i < len(v); i++ {
+			if v[i] < min {
+				min = v[i]
+			}
+		}
+		return min, nil
+	case []float64:
+		if len(v) == 0 {
+			return Null{}, errors.New("Invalid length of " + reflect.TypeOf(v).String())
+		}
+		min := v[0]
+		for i := 1; i < len(v); i++ {
+			if v[i] < min {
+				min = v[i]
+			}
+		}
+		return min, nil
+	}
+
+	return Null{}, errors.New("Invalid argument of type " + reflect.TypeOf(values).String())
+}

--- a/dfl/Null.go
+++ b/dfl/Null.go
@@ -1,0 +1,11 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+// Null is used as return value for Extract and DFL functions instead of returning nil pointers.
+type Null struct{}

--- a/dfl/Parse.go
+++ b/dfl/Parse.go
@@ -8,9 +8,10 @@
 package dfl
 
 import (
+	//"fmt"
 	"regexp"
 	"strings"
-	"unicode"
+	//"unicode"
 )
 
 import (
@@ -20,6 +21,7 @@ import (
 // Parse is the primary entrypoint for the DFL library.
 // Parse takes a DFL expression string as input and returns an Abstract Synatax Tree (AST), and error if any.
 func Parse(in string) (Node, error) {
+
 	var root Node
 
 	if len(in) == 0 {
@@ -31,26 +33,23 @@ func Parse(in string) (Node, error) {
 		return root, err
 	}
 
-	if strings.HasPrefix(strings.TrimLeftFunc(in, unicode.IsSpace), "@") {
-		return ParseAttribute(in)
-	} else {
+	parentheses := 0
+	curlybrackets := 0
+	squarebrackets := 0
+	singlequotes := 0
+	doublequotes := 0
+	for i, c := range in {
 
-		parentheses := 0
-		curlybrackets := 0
-		squarebrackets := 0
-		singlequotes := 0
-		doublequotes := 0
-		for i, c := range in {
+		s := strings.TrimSpace(in[0 : i+1])
+		s_lc := strings.ToLower(s)
+		remainder := strings.TrimSpace(in[i+1:])
 
-			s := strings.TrimSpace(in[0 : i+1])
-			s_lc := strings.ToLower(s)
-			remainder := strings.TrimSpace(in[i+1:])
-
-			if c == '(' {
-				parentheses += 1
-			} else if c == ')' {
-				parentheses -= 1
-			} else if squarebrackets == 0 && c == '[' {
+		if c == '(' {
+			parentheses += 1
+		} else if c == ')' {
+			parentheses -= 1
+		} else if singlequotes == 0 && doublequotes == 0 {
+			if squarebrackets == 0 && c == '[' {
 				squarebrackets += 1
 			} else if squarebrackets == 1 && c == ']' {
 				squarebrackets -= 1
@@ -58,25 +57,109 @@ func Parse(in string) (Node, error) {
 				curlybrackets += 1
 			} else if curlybrackets == 1 && c == '}' {
 				curlybrackets -= 1
-			} else if singlequotes == 1 && c == '\'' {
-				singlequotes -= 1
-			} else if singlequotes == 0 && c == '\'' {
+			} else if c == '\'' {
 				singlequotes += 1
-			} else if doublequotes == 1 && c == '"' {
-				doublequotes -= 1
-			} else if doublequotes == 0 && c == '"' {
+			} else if c == '"' {
 				doublequotes += 1
 			}
+		} else if singlequotes == 1 && c == '\'' {
+			singlequotes -= 1
+		} else if doublequotes == 1 && c == '"' {
+			doublequotes -= 1
+		}
 
-			if parentheses == 0 && squarebrackets == 0 && curlybrackets == 0 && singlequotes == 0 && doublequotes == 0 && (len(remainder) == 0 || in[i+1] == ' ') {
+		if parentheses == 0 &&
+			squarebrackets == 0 &&
+			curlybrackets == 0 &&
+			singlequotes == 0 &&
+			doublequotes == 0 {
+			if s_lc == "?:" {
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &Coalesce{&BinaryOperator{Right: right}}, nil
+			} else if s_lc == ">=" {
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &GreaterThanOrEqual{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+			} else if s_lc == "<" && in[i+1] != '=' {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &LessThan{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+
+			} else if s_lc == "<=" {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &LessThanOrEqual{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+
+			} else if s_lc == ">" && in[i+1] != '=' {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &GreaterThan{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+
+			} else if s_lc == ">=" {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &GreaterThanOrEqual{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+
+			} else if s_lc == "==" {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &Equal{&BinaryOperator{Right: right}}, nil
+
+			} else if s_lc == "!=" {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &NotEqual{&BinaryOperator{Right: right}}, nil
+
+			} else if s_lc == "+" {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &Add{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+
+			} else if s_lc == "-" {
+
+				right, err := Parse(remainder)
+				if err != nil {
+					return right, err
+				}
+				return &Subtract{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
+
+			} else if len(remainder) == 0 || in[i+1] == ' ' || in[i+1] == '\n' {
 				if len(s) >= 2 && ((strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) || (strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\""))) {
 					return ParseLiteral(s[1:len(s)-1], remainder)
+				} else if strings.HasPrefix(s, "@") {
+					return ParseAttribute(s, remainder)
 				} else if len(s) >= 2 && strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
-					return ParseArray(s[1:len(s)-1], remainder)
+					return ParseArray(strings.TrimSpace(s[1:len(s)-1]), remainder)
 				} else if len(s) >= 2 && strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
-					return ParseSet(s[1:len(s)-1], remainder)
+					return ParseSet(strings.TrimSpace(s[1:len(s)-1]), remainder)
 				} else if len(s) >= 2 && strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
-					return ParseSub(s[1:len(s)-1], remainder)
+					return ParseSub(strings.TrimSpace(s[1:len(s)-1]), remainder)
 				} else if s_lc == "and" {
 
 					right, err := Parse(remainder)
@@ -100,70 +183,6 @@ func Parse(in string) (Node, error) {
 						return right, err
 					}
 					return &Xor{&BinaryOperator{Right: right}}, nil
-
-				} else if s_lc == "<" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &LessThan{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
-
-				} else if s_lc == "<=" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &LessThanOrEqual{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
-
-				} else if s_lc == ">" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &GreaterThan{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
-
-				} else if s_lc == ">=" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &GreaterThanOrEqual{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
-
-				} else if s_lc == "==" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &Equal{&BinaryOperator{Right: right}}, nil
-
-				} else if s_lc == "!=" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &NotEqual{&BinaryOperator{Right: right}}, nil
-
-				} else if s_lc == "+" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &Add{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
-
-				} else if s_lc == "-" {
-
-					right, err := Parse(remainder)
-					if err != nil {
-						return right, err
-					}
-					return &Subtract{&NumericBinaryOperator{&BinaryOperator{Right: right}}}, nil
 
 				} else if s_lc == "not" {
 
@@ -214,13 +233,15 @@ func Parse(in string) (Node, error) {
 					return &After{&TemporalBinaryOperator{&BinaryOperator{Right: right}}}, nil
 
 				} else if re.MatchString(s) {
-					return ParseFunction(s, remainder, re)
+					return ParseFunction(s, remainder)
 				} else {
 					return ParseLiteral(TryConvertString(s), remainder)
 				}
-			}
+			} else {
 
+			}
 		}
+
 	}
 
 	return root, errors.New("Invalid expression syntax for \"" + in + "\".")

--- a/dfl/ParseAndCompileExpressions.go
+++ b/dfl/ParseAndCompileExpressions.go
@@ -1,0 +1,25 @@
+// =================================================================
+//
+// Copyright (C) 2018 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package dfl
+
+import (
+	"github.com/pkg/errors"
+)
+
+// ParseAndCompileExpressions is a usability function to parse and compile multiple expressions.
+func ParseAndCompileExpressions(expressions map[string]string) (map[string]Node, error) {
+	nodes := map[string]Node{}
+	for k, exp := range expressions {
+		node, err := Parse(exp)
+		if err != nil {
+			return nodes, errors.Wrap(err, "error parsing expression "+exp)
+		}
+		nodes[k] = node.Compile()
+	}
+	return nodes, nil
+}

--- a/dfl/ParseArray.go
+++ b/dfl/ParseArray.go
@@ -8,16 +8,10 @@
 package dfl
 
 import (
-	"fmt"
-	"strings"
-	"unicode"
-)
-
-import (
 	"github.com/pkg/errors"
 )
 
-// ParseArray parses an Array Node and recursively any remainder.
+// ParseArray parses an array of nodes.
 // If parameter "in" is gramatically a child node, then return the parent node.
 // DFL arrays can include Attribute or Literal Nodes.
 // As all attribute references must start with an "@" character, parantheses are optional for literals except if a comma exists.
@@ -28,45 +22,7 @@ import (
 //	[Taco, Tacos, Burrito, Burritos, "Mexican Food", @example]
 func ParseArray(in string, remainder string) (Node, error) {
 
-	nodes := make([]Node, 0)
-	singlequotes := 0
-	doublequotes := 0
-
-	in = strings.TrimSpace(in)
-	s := ""
-
-	for i, c := range in {
-
-		if !(singlequotes == 0 && doublequotes == 0 && c == ',') {
-			s += string(c)
-			if c == '\'' && doublequotes == 0 {
-				if singlequotes == 0 {
-					singlequotes += 1
-				} else {
-					singlequotes -= 1
-				}
-			} else if c == '"' && singlequotes == 0 {
-				if doublequotes == 0 {
-					doublequotes += 1
-				} else {
-					doublequotes -= 1
-				}
-			}
-		}
-
-		if singlequotes == 0 && doublequotes == 0 && (i+1 == len(in) || in[i+1] == ',') {
-			s = strings.TrimSpace(s)
-			if len(s) >= 2 && ((strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) || (strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\""))) {
-				nodes = append(nodes, &Literal{Value: s[1 : len(s)-1]})
-			} else if strings.HasPrefix(strings.TrimLeftFunc(s, unicode.IsSpace), "@") {
-				nodes = append(nodes, &Attribute{Name: strings.TrimLeftFunc(s, unicode.IsSpace)[1:]})
-			} else {
-				nodes = append(nodes, &Literal{Value: TryConvertString(s)})
-			}
-			s = ""
-		}
-
-	}
+	nodes := ParseList(in)
 
 	if len(remainder) == 0 {
 		return &Array{Nodes: nodes}, nil
@@ -77,42 +33,12 @@ func ParseArray(in string, remainder string) (Node, error) {
 	if err != nil {
 		return root, err
 	}
-	switch root.(type) {
-	case *And:
-		root.(*And).Left = left
-	case *Or:
-		root.(*Or).Left = left
-	case *Xor:
-		root.(*Xor).Left = left
-	case *In:
-		root.(*In).Left = left
-	case *Like:
-		root.(*Like).Left = left
-	case *ILike:
-		root.(*ILike).Left = left
-	case *LessThan:
-		root.(*LessThan).Left = left
-	case *LessThanOrEqual:
-		root.(*LessThanOrEqual).Left = left
-	case *GreaterThan:
-		root.(*GreaterThan).Left = left
-	case *GreaterThanOrEqual:
-		root.(*GreaterThanOrEqual).Left = left
-	case *Equal:
-		root.(*Equal).Left = left
-	case *NotEqual:
-		root.(*NotEqual).Left = left
-	case *Add:
-		root.(*Add).Left = left
-	case *Subtract:
-		root.(*Subtract).Left = left
-	case *Before:
-		root.(*Before).Left = left
-	case *After:
-		root.(*After).Left = left
-	default:
-		return root, errors.New("Invalid expression syntax for " + fmt.Sprint(remainder) + ".  Root is not a binary operator")
+
+	err = AttachLeft(root, left)
+	if err != nil {
+		return root, errors.Wrap(err, "error attaching left for "+in)
 	}
+
 	return root, nil
 
 }

--- a/dfl/ParseList.go
+++ b/dfl/ParseList.go
@@ -12,20 +12,8 @@ import (
 	"unicode"
 )
 
-import (
-	"github.com/pkg/errors"
-)
-
-// ParseSet parses a Set Node and recursively any remainder.
-// If parameter "in" is gramatically a child node, then return the parent node.
-// DFL sets can include Attribute or Literal Nodes.
-// As all attribute references must start with an "@" character, parantheses are optional for literals except if a comma exists.
-// Below are some example inputs
-//
-//	{bank, bureau_de_change, atm}
-//	{1, 2, @target}
-//	{Taco, Tacos, Burrito, Burritos, "Mexican Food", @example}
-func ParseSet(in string, remainder string) (Node, error) {
+// ParseList parses a list of values.
+func ParseList(in string) []Node {
 
 	nodes := make([]Node, 0)
 	singlequotes := 0
@@ -67,21 +55,5 @@ func ParseSet(in string, remainder string) (Node, error) {
 
 	}
 
-	if len(remainder) == 0 {
-		return &Set{Nodes: nodes}, nil
-	}
-
-	left := &Set{Nodes: nodes}
-	root, err := Parse(remainder)
-	if err != nil {
-		return root, err
-	}
-
-	err = AttachLeft(root, left)
-	if err != nil {
-		return root, errors.Wrap(err, "error attaching left for set "+in)
-	}
-
-	return root, nil
-
+	return nodes
 }

--- a/dfl/ParseLiteral.go
+++ b/dfl/ParseLiteral.go
@@ -32,43 +32,13 @@ func ParseLiteral(v interface{}, remainder string) (Node, error) {
 	left := &Literal{Value: v}
 	root, err := Parse(remainder)
 	if err != nil {
-		return root, err
+		return root, errors.Wrap(err, "error parsing remainder < "+remainder+" >")
 	}
-	switch root.(type) {
-	case *And:
-		root.(*And).Left = left
-	case *Or:
-		root.(*Or).Left = left
-	case *Xor:
-		root.(*Xor).Left = left
-	case *In:
-		root.(*In).Left = left
-	case *Like:
-		root.(*Like).Left = left
-	case *ILike:
-		root.(*ILike).Left = left
-	case *LessThan:
-		root.(*LessThan).Left = left
-	case *LessThanOrEqual:
-		root.(*LessThanOrEqual).Left = left
-	case *GreaterThan:
-		root.(*GreaterThan).Left = left
-	case *GreaterThanOrEqual:
-		root.(*GreaterThanOrEqual).Left = left
-	case *Equal:
-		root.(*Equal).Left = left
-	case *NotEqual:
-		root.(*NotEqual).Left = left
-	case *Add:
-		root.(*Add).Left = left
-	case *Subtract:
-		root.(*Subtract).Left = left
-	case *Before:
-		root.(*Before).Left = left
-	case *After:
-		root.(*After).Left = left
-	default:
-		return root, errors.New("Invalid expression syntax for " + fmt.Sprint(v) + ".  Root is not a binary operator")
+
+	err = AttachLeft(root, left)
+	if err != nil {
+		return root, errors.Wrap(err, "Could not attach left "+fmt.Sprint(v))
 	}
+
 	return root, nil
 }

--- a/dfl/ParseSub.go
+++ b/dfl/ParseSub.go
@@ -34,41 +34,9 @@ func ParseSub(s string, remainder string) (Node, error) {
 		return root, err
 	}
 
-	switch root.(type) {
-	case *And:
-		root.(*And).Left = left
-	case *Or:
-		root.(*Or).Left = left
-	case *Xor:
-		root.(*Xor).Left = left
-	case *In:
-		root.(*In).Left = left
-	case *Like:
-		root.(*Like).Left = left
-	case *ILike:
-		root.(*ILike).Left = left
-	case *LessThan:
-		root.(*LessThan).Left = left
-	case *LessThanOrEqual:
-		root.(*LessThanOrEqual).Left = left
-	case *GreaterThan:
-		root.(*GreaterThan).Left = left
-	case *GreaterThanOrEqual:
-		root.(*GreaterThanOrEqual).Left = left
-	case *Equal:
-		root.(*Equal).Left = left
-	case *NotEqual:
-		root.(*NotEqual).Left = left
-	case *Add:
-		root.(*Add).Left = left
-	case *Subtract:
-		root.(*Subtract).Left = left
-	case *Before:
-		root.(*Before).Left = left
-	case *After:
-		root.(*After).Left = left
-	default:
-		return root, errors.New("Invalid expression syntax for " + s + ".  Root is not a binary operator")
+	err = AttachLeft(root, left)
+	if err != nil {
+		return root, errors.Wrap(err, "error attaching left for "+s)
 	}
 
 	return root, nil

--- a/scripts/build_cli.sh
+++ b/scripts/build_cli.sh
@@ -9,6 +9,9 @@ echo "******************"
 echo "Formatting $DIR/../cmd/dfl"
 cd $DIR/../cmd/dfl
 go fmt
+echo "Formatting $DIR/../dfl"
+cd $DIR/../dfl
+go fmt
 echo "Done formatting."
 echo "******************"
 echo "Building program for go-dfl"

--- a/scripts/build_javascript.sh
+++ b/scripts/build_javascript.sh
@@ -8,11 +8,14 @@ echo "******************"
 echo "Formatting $(realpath $DIR/../dfl)"
 cd $DIR/../dfl
 go fmt
+echo "Formatting $DIR/../dfl"
+cd $DIR/../dfl
+go fmt
 echo "Done formatting."
 echo "******************"
 echo "Building Javascript for DFL"
 cd $DIR/../bin
-gopherjs build github.com/spatialcurrent/go-dfl/cmd/dfljs
+gopherjs build -o dfl.js github.com/spatialcurrent/go-dfl/cmd/dfl.js
 if [[ "$?" != 0 ]] ; then
     echo "Error building Javascript for DFL"
     exit 1


### PR DESCRIPTION
**Multi-line expressions & Sub-functions**

For example:

```
(@size >= len('{"type":"Point"}')) and
(first(trim(@content)) == '{') and
(last(trim(@content)) == '}') and
(
  @data?.type in [
    "FeatureCollection",
    "Feature",
    "Geometry",
    "Point",
    "LineString",
    "Polygon",
    "MultiPoint",
    "MultiLineString",
    "MultiPolygon"
  ]
)

```

**Other Enhancements**

- Refractored to use new `AttachLeft` function.
- New `dfl.NewFuntionMapWithDefaults()` function which returns FunctioMap with functions: `map`, `split`, `trim`, `len`, `bytes`, `int32`, `big`, `repeat`, `string`, `min`, `max`, `lower`, `upper`, `first`, `last`.
- Attributes now support deep properties `@a.b.c`, a null-safe operator (`@a?.b?.c`), and array indexing.  See new `Extract` function.
- New coalesce operator: `a ?: b`
- New `ParseAndCompileExpressions` usability function for parsing and compiling multiple expressions.